### PR TITLE
Add implementation notes template and maintenance guidance

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -1,0 +1,24 @@
+# Implementation Notes
+
+This document records the work completed on the project across iterations. Each update should summarize the features delivered, the documentation consulted, any parsed data fields with their provenance, and the validation steps that confirmed the changes. Treat the parsed link list derived from [`Training Documents/Reference Links for app v3.docx`](Training%20Documents/Reference%20Links%20for%20app%20v3.docx) as the authoritative source when referencing external documentation.
+
+## Feature Summaries
+- _Iteration:_ 
+  - _Summary:_ 
+  - _Related Issues / Tickets:_ 
+
+## Documentation URLs Consulted
+- _Iteration:_ 
+  - _Authoritative Source:_ `Training Documents/Reference Links for app v3.docx`
+  - _Additional References:_ 
+
+## Parsed Data Fields with Provenance
+- _Iteration:_ 
+  - _Source:_ `Training Documents/Reference Links for app v3.docx`
+  - _Field:_ 
+  - _Usage:_ 
+
+## Validation Steps
+- _Iteration:_ 
+  - _Checks Performed:_ 
+  - _Command Output / Evidence:_ 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # beta
+
 going to try to go one at a time.
+
+## Maintaining Implementation Notes
+
+Each time you add or modify functionality:
+
+1. Record the work in `IMPLEMENTATION_NOTES.md` using the provided template sections (Feature Summaries, Documentation URLs Consulted, Parsed Data Fields with Provenance, Validation Steps).
+2. When noting documentation, rely on the parsed link list derived from [`Training Documents/Reference Links for app v3.docx`](Training%20Documents/Reference%20Links%20for%20app%20v3.docx) as the authoritative source and include any additional references consulted.
+3. Update the parsed data fields section with every new or modified field, including its provenance and usage.
+4. Document the commands or tests executed to validate the work, along with any pertinent output or evidence.
+5. Commit the updates to `IMPLEMENTATION_NOTES.md` alongside the code changes so the history remains synchronized with project development.


### PR DESCRIPTION
## Summary
- add an IMPLEMENTATION_NOTES.md template that highlights the required reporting sections and authoritative link list
- document the process for updating implementation notes in the README to keep future work compliant

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7253cc62483299399b199948cc0b5