### PR TITLE
Add JWST spectral viewer package with MAST integration

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -1,24 +1,32 @@
 # Implementation Notes
 
-This document records the work completed on the project across iterations. Each update should summarize the features delivered, the documentation consulted, any parsed data fields with their provenance, and the validation steps that confirmed the changes. Treat the parsed link list derived from [`Training Documents/Reference Links for app v3.docx`](Training%20Documents/Reference%20Links%20for%20app%20v3.docx) as the authoritative source when referencing external documentation.
+This document records the work completed on the project across iterations. Each update should summarize the features delivered,
+the documentation consulted, any parsed data fields with their provenance, and the validation steps that confirmed the changes.
+Treat the parsed link list derived from [`Training Documents/Reference Links for app v3.docx`](Training%20Documents/Reference%20Links%20for%20app%20v3.docx) as the authoritative source when referencing external documentation.
 
 ## Feature Summaries
-- _Iteration:_ 
-  - _Summary:_ 
-  - _Related Issues / Tickets:_ 
+- _Iteration:_ Initial JWST viewer build
+  - _Summary:_ Added a modular JWST spectral viewer package with MAST discovery, Specutils-based parsing, Plotly interactivity, and provenance surfacing wired into the CLI entry point.
+  - _Related Issues / Tickets:_ N/A
 
 ## Documentation URLs Consulted
-- _Iteration:_ 
+- _Iteration:_ Initial JWST viewer build
   - _Authoritative Source:_ `Training Documents/Reference Links for app v3.docx`
-  - _Additional References:_ 
+  - _Additional References:_
+    - https://astroquery.readthedocs.io/en/latest/mast/mast_obsquery.html
+    - https://astroquery.readthedocs.io/en/latest/mast/mast.html#observation-products
+    - https://mast.stsci.edu/api/v0/pyex.html
+    - https://specutils.readthedocs.io/en/stable/spectrum1d.html#reading-from-files
 
 ## Parsed Data Fields with Provenance
-- _Iteration:_ 
+- _Iteration:_ Initial JWST viewer build
   - _Source:_ `Training Documents/Reference Links for app v3.docx`
-  - _Field:_ 
-  - _Usage:_ 
+  - _Field:_ JWST observation metadata (program ID, instrument, target, PI, collection) from MAST Observations and product tables.
+  - _Usage:_ Displayed within the Mission & Instrument panel for provenance and linking back to MAST resources.
+  - _Field:_ FITS header metadata (telescope, instrument, program, observation, visit, target, pipeline version).
+  - _Usage:_ Rendered in the Citations / Provenance panel to expose product lineage and calibration context.
 
 ## Validation Steps
-- _Iteration:_ 
-  - _Checks Performed:_ 
-  - _Command Output / Evidence:_ 
+- _Iteration:_ Initial JWST viewer build
+  - _Checks Performed:_ `PYTHONPATH=src python -m jwst_viewer --help`
+  - _Command Output / Evidence:_ Help text rendered confirming CLI wiring.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+"""Convenience entry point for launching the JWST spectral viewer."""
+from jwst_viewer.__main__ import main
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "jwst-viewer"
+version = "0.1.0"
+description = "JWST spectral viewer with MAST integration"
+authors = [{name = "Beta User"}]
+requires-python = ">=3.10"
+dependencies = [
+  "astroquery>=0.4.7",
+  "astropy>=6.0",
+  "specutils>=1.14",
+  "plotly>=5.20",
+]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/jwst_viewer/__init__.py
+++ b/src/jwst_viewer/__init__.py
@@ -1,0 +1,13 @@
+"""JWST spectral viewer package."""
+
+from .mast_client import JWSTMastClient, JWSTProductMetadata
+from .spectrum_loader import JWSTSpectrumLoader, SpectrumBundle
+from .viewer import render_viewer_html
+
+__all__ = [
+    "JWSTMastClient",
+    "JWSTProductMetadata",
+    "JWSTSpectrumLoader",
+    "SpectrumBundle",
+    "render_viewer_html",
+]

--- a/src/jwst_viewer/__main__.py
+++ b/src/jwst_viewer/__main__.py
@@ -1,0 +1,92 @@
+"""Command line entry point for the JWST spectral viewer."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, Optional
+
+from astropy import units as u
+
+from .mast_client import JWSTMastClient
+from .spectrum_loader import JWSTSpectrumLoader
+from .viewer import render_viewer_html
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="JWST spectral viewer")
+    parser.add_argument("program_id", help="JWST program/proposal identifier")
+    parser.add_argument(
+        "--instrument",
+        dest="instrument",
+        help="Instrument name (e.g. NIRSpec, MIRI) to narrow the search",
+    )
+    parser.add_argument(
+        "--target",
+        dest="target",
+        help="Target name to narrow the query",
+    )
+    parser.add_argument(
+        "--download-dir",
+        dest="download_dir",
+        default="downloads",
+        help="Directory where products are cached",
+    )
+    parser.add_argument(
+        "--output-html",
+        dest="output_html",
+        default="jwst_viewer.html",
+        help="Path to write the interactive HTML viewer",
+    )
+    parser.add_argument(
+        "--flux-unit",
+        dest="flux_unit",
+        default="Jy",
+        help="Flux unit for display (astropy unit string)",
+    )
+    parser.add_argument(
+        "--wave-unit",
+        dest="wave_unit",
+        default="micron",
+        help="Spectral axis unit for display (astropy unit string)",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    flux_unit = u.Unit(args.flux_unit)
+    wave_unit = u.Unit(args.wave_unit)
+
+    client = JWSTMastClient(download_dir=args.download_dir)
+    observations, products, paths, metadata = client.discover_and_download(
+        program_id=args.program_id,
+        instrument_name=args.instrument,
+        target_name=args.target,
+    )
+
+    if not paths:
+        parser.error("No spectral products were found for the specified query.")
+
+    loader = JWSTSpectrumLoader(preferred_flux_unit=flux_unit, preferred_wave_unit=wave_unit)
+    bundle = loader.load(paths[0])
+
+    provenance: Dict[str, Optional[str]] = {
+        **{key: (str(value) if value is not None else None) for key, value in bundle.header_metadata.items()},
+        "round_trip_verified": str(bundle.round_trip_verified),
+        "primary_product": paths[0].name,
+    }
+
+    render_viewer_html(
+        bundle.spectrum,
+        metadata=metadata,
+        header_metadata=provenance,
+        output_path=Path(args.output_html),
+    )
+
+    print(f"Viewer written to {args.output_html}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jwst_viewer/mast_client.py
+++ b/src/jwst_viewer/mast_client.py
@@ -1,0 +1,166 @@
+"""MAST client helpers for JWST data discovery and download."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from astroquery.mast import Observations  # type: ignore
+from astropy.table import Table
+
+
+@dataclass
+class JWSTProductMetadata:
+    """Metadata captured for provenance displays."""
+
+    observation_id: str
+    program_id: str
+    instrument: str
+    target_name: str
+    obs_collection: str
+    proposal_pi: Optional[str]
+    product_url: Optional[str]
+    product_filename: Optional[str]
+    download_path: Optional[Path] = None
+    additional_fields: Dict[str, Any] | None = None
+
+
+class JWSTMastClient:
+    """High level helper around :mod:`astroquery.mast` for JWST spectra."""
+
+    def __init__(self, download_dir: Path | str = "downloads") -> None:
+        self.download_dir = Path(download_dir)
+
+    def discover_observations(
+        self,
+        *,
+        program_id: Optional[str] = None,
+        target_name: Optional[str] = None,
+        instrument_name: Optional[str] = None,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> Table:
+        """Query MAST for JWST observations that contain spectra."""
+
+        query_args: Dict[str, Any] = {
+            "obs_collection": "JWST",
+            "dataproduct_type": "spectrum",
+        }
+        if program_id:
+            query_args["proposal_id"] = program_id
+        if target_name:
+            query_args["target_name"] = target_name
+        if instrument_name:
+            query_args["instrument_name"] = instrument_name
+        if filters:
+            query_args.update(filters)
+
+        # Usage follows the Observations query workflow documented at:
+        # https://astroquery.readthedocs.io/en/latest/mast/mast_obsquery.html
+        observations = Observations.query_criteria(**query_args)
+        return observations
+
+    def discover_products(self, observations: Table) -> Table:
+        """Return the filtered list of Level-2 spectral products for the observations."""
+
+        if len(observations) == 0:
+            return Table()
+
+        # The product listing/filters follow the documented pattern:
+        # https://astroquery.readthedocs.io/en/latest/mast/mast.html#observation-products
+        product_list = Observations.get_product_list(observations)
+        spectral_products = Observations.filter_products(
+            product_list,
+            productType="SCIENCE",
+            productLevel="2",
+            extension="fits",
+        )
+        return spectral_products
+
+    def download_products(
+        self, products: Table, *, mrp_only: bool = True, cache: bool = True
+    ) -> List[Path]:
+        """Download the requested products if any exist."""
+
+        if len(products) == 0:
+            return []
+
+        self.download_dir.mkdir(parents=True, exist_ok=True)
+        # Download helper per the MAST API examples:
+        # https://mast.stsci.edu/api/v0/pyex.html
+        manifest = Observations.download_products(
+            products,
+            download_dir=str(self.download_dir),
+            mrp_only=mrp_only,
+            cache=cache,
+        )
+        if manifest is None:
+            return []
+
+        paths: List[Path] = []
+        for row in manifest:
+            local_path = Path(row["Local Path"])
+            if local_path.exists():
+                paths.append(local_path)
+        return paths
+
+    def collect_metadata(
+        self, observations: Table, products: Table, downloaded_paths: Iterable[Path]
+    ) -> List[JWSTProductMetadata]:
+        """Assemble metadata records for provenance display."""
+
+        paths_by_name = {path.name: path for path in downloaded_paths}
+        metadata: List[JWSTProductMetadata] = []
+        for product in products:
+            obs_id = product.get("obsid")
+            obs_rows = observations[observations["obsid"] == obs_id]
+            program_id = product.get("proposal_id")
+            instrument = product.get("instrument_name")
+            target_name = product.get("target_name")
+            obs_collection = product.get("obs_collection")
+            proposal_pi = (
+                obs_rows[0].get("proposal_pi") if len(obs_rows) else product.get("proposal_pi")
+            )
+            filename = product.get("productFilename")
+            download_path = paths_by_name.get(filename) if filename else None
+            metadata.append(
+                JWSTProductMetadata(
+                    observation_id=str(obs_id),
+                    program_id=str(program_id) if program_id is not None else "",
+                    instrument=str(instrument) if instrument is not None else "",
+                    target_name=str(target_name) if target_name is not None else "",
+                    obs_collection=str(obs_collection) if obs_collection is not None else "",
+                    proposal_pi=str(proposal_pi) if proposal_pi is not None else None,
+                    product_url=product.get("dataURI"),
+                    product_filename=filename,
+                    download_path=download_path,
+                    additional_fields={
+                        "obs_title": product.get("obs_title"),
+                        "t_exptime": product.get("t_exptime"),
+                        "instrument_id": product.get("instrument_id"),
+                    },
+                )
+            )
+        return metadata
+
+    def discover_and_download(
+        self,
+        *,
+        program_id: Optional[str] = None,
+        target_name: Optional[str] = None,
+        instrument_name: Optional[str] = None,
+        filters: Optional[Dict[str, Any]] = None,
+        mrp_only: bool = True,
+        cache: bool = True,
+    ) -> tuple[Table, Table, List[Path], List[JWSTProductMetadata]]:
+        """Full workflow: discover observations, filter spectral products, download, and collect metadata."""
+
+        observations = self.discover_observations(
+            program_id=program_id,
+            target_name=target_name,
+            instrument_name=instrument_name,
+            filters=filters,
+        )
+        products = self.discover_products(observations)
+        downloaded_paths = self.download_products(products, mrp_only=mrp_only, cache=cache)
+        metadata = self.collect_metadata(observations, products, downloaded_paths)
+        return observations, products, downloaded_paths, metadata

--- a/src/jwst_viewer/spectrum_loader.py
+++ b/src/jwst_viewer/spectrum_loader.py
@@ -1,0 +1,105 @@
+"""Spectrum loading utilities for JWST Level-2 products."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+from astropy import units as u
+from astropy.io import fits
+from specutils import Spectrum1D  # type: ignore
+
+
+@dataclass
+class SpectrumBundle:
+    """Container for the parsed spectrum and associated metadata."""
+
+    spectrum: Spectrum1D
+    header_metadata: Dict[str, Any]
+    round_trip_verified: bool
+
+
+class JWSTSpectrumLoader:
+    """Parse JWST spectral products into :class:`specutils.Spectrum1D`."""
+
+    def __init__(self, *, preferred_flux_unit: u.Unit = u.Jy, preferred_wave_unit: u.Unit = u.micron) -> None:
+        self.preferred_flux_unit = preferred_flux_unit
+        self.preferred_wave_unit = preferred_wave_unit
+
+    def load(self, file_path: Path | str) -> SpectrumBundle:
+        """Load a JWST spectral FITS file into memory."""
+
+        file_path = Path(file_path)
+        # Spectrum1D.read is the recommended API from the specutils docs:
+        # https://specutils.readthedocs.io/en/stable/spectrum1d.html#reading-from-files
+        spectrum = Spectrum1D.read(file_path)
+
+        header_metadata = self._extract_header_metadata(file_path)
+        converted_spectrum, verified = self._apply_preferred_units(spectrum)
+        return SpectrumBundle(
+            spectrum=converted_spectrum,
+            header_metadata=header_metadata,
+            round_trip_verified=verified,
+        )
+
+    def _apply_preferred_units(self, spectrum: Spectrum1D) -> Tuple[Spectrum1D, bool]:
+        """Convert the spectrum into the preferred units while checking reversibility."""
+
+        converted = spectrum
+        if spectrum.flux.unit != self.preferred_flux_unit:
+            converted = converted.to(unit=self.preferred_flux_unit)
+        if spectrum.spectral_axis.unit != self.preferred_wave_unit:
+            converted = Spectrum1D(
+                flux=converted.flux,
+                spectral_axis=converted.spectral_axis.to(self.preferred_wave_unit),
+            )
+
+        verified = self._verify_round_trip(converted)
+        return converted, verified
+
+    def _verify_round_trip(self, spectrum: Spectrum1D, *, atol: float = 1e-12) -> bool:
+        """Ensure unit conversions round-trip without numerical drift."""
+
+        flux_back = spectrum.flux.to(spectrum.flux.unit).value
+        spectral_back = spectrum.spectral_axis.to(spectrum.spectral_axis.unit).value
+        flux_original = spectrum.flux.value
+        spectral_original = spectrum.spectral_axis.value
+        flux_close = np.allclose(flux_back, flux_original, atol=atol, rtol=1e-9)
+        spectral_close = np.allclose(spectral_back, spectral_original, atol=atol, rtol=1e-9)
+        return bool(flux_close and spectral_close)
+
+    def _extract_header_metadata(self, file_path: Path) -> Dict[str, Any]:
+        """Collect the header keywords required for provenance."""
+
+        metadata: Dict[str, Any] = {}
+        with fits.open(file_path) as hdul:
+            header = hdul[0].header
+            metadata.update({
+                "telescope": header.get("TELESCOP"),
+                "instrument": header.get("INSTRUME"),
+                "program_id": header.get("PROGRAM"),
+                "observation": header.get("OBS_ID"),
+                "visit": header.get("VISIT"),
+                "target": header.get("TARGNAME"),
+                "pipeline_version": header.get("CAL_VER"),
+            })
+        return metadata
+
+    def convert_units(
+        self,
+        spectrum: Spectrum1D,
+        *,
+        flux_unit: Optional[u.Unit] = None,
+        spectral_axis_unit: Optional[u.Unit] = None,
+    ) -> Tuple[Spectrum1D, bool]:
+        """Return a new spectrum converted to the requested units plus round-trip status."""
+
+        flux_unit = flux_unit or self.preferred_flux_unit
+        spectral_axis_unit = spectral_axis_unit or self.preferred_wave_unit
+        converted = Spectrum1D(
+            flux=spectrum.flux.to(flux_unit),
+            spectral_axis=spectrum.spectral_axis.to(spectral_axis_unit),
+        )
+        verified = self._verify_round_trip(converted)
+        return converted, verified

--- a/src/jwst_viewer/viewer.py
+++ b/src/jwst_viewer/viewer.py
@@ -1,0 +1,216 @@
+"""Interactive viewer utilities built on Plotly."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import plotly.graph_objects as go
+from plotly.utils import PlotlyJSONEncoder
+from astropy import units as u
+from specutils import Spectrum1D  # type: ignore
+
+from .mast_client import JWSTProductMetadata
+
+
+def _format_metadata_items(metadata: Iterable[JWSTProductMetadata]) -> List[Dict[str, Optional[str]]]:
+    return [
+        {
+            "Observation ID": item.observation_id,
+            "Program ID": item.program_id,
+            "Instrument": item.instrument,
+            "Target": item.target_name,
+            "PI": item.proposal_pi,
+            "Collection": item.obs_collection,
+            "Download": str(item.download_path) if item.download_path else item.product_url,
+        }
+        for item in metadata
+    ]
+
+
+def _build_figure(
+    spectrum: Spectrum1D,
+    *,
+    alternate_flux_unit: u.Unit = u.Unit("erg / (cm2 s Angstrom)"),
+    alternate_wave_unit: u.Unit = u.AA,
+) -> go.Figure:
+    wavelength_primary = spectrum.spectral_axis.to(spectrum.spectral_axis.unit)
+    flux_primary = spectrum.flux.to(spectrum.flux.unit)
+    wavelength_alt = spectrum.spectral_axis.to(alternate_wave_unit)
+    flux_alt = spectrum.flux.to(alternate_flux_unit)
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=wavelength_primary.value,
+            y=flux_primary.value,
+            mode="lines",
+            name=f"{spectrum.spectral_axis.unit:latex_inline} / {spectrum.flux.unit:latex_inline}",
+        )
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=wavelength_alt.value,
+            y=flux_alt.value,
+            mode="lines",
+            visible=False,
+            name=f"{alternate_wave_unit.to_string()} / {alternate_flux_unit.to_string()}",
+        )
+    )
+
+    fig.update_layout(
+        title="JWST Spectrum",
+        xaxis_title=f"Wavelength [{spectrum.spectral_axis.unit}]",
+        yaxis_title=f"Flux [{spectrum.flux.unit}]",
+        hovermode="x",
+        updatemenus=[
+            {
+                "buttons": [
+                    {
+                        "label": f"{spectrum.spectral_axis.unit.to_string()} / {spectrum.flux.unit.to_string()}",
+                        "method": "update",
+                        "args": [
+                            {"visible": [True, False]},
+                            {
+                                "xaxis": {"title": f"Wavelength [{spectrum.spectral_axis.unit}]"},
+                                "yaxis": {"title": f"Flux [{spectrum.flux.unit}]"},
+                            },
+                        ],
+                    },
+                    {
+                        "label": f"{alternate_wave_unit.to_string()} / {alternate_flux_unit.to_string()}",
+                        "method": "update",
+                        "args": [
+                            {"visible": [False, True]},
+                            {
+                                "xaxis": {"title": f"Wavelength [{alternate_wave_unit}]"},
+                                "yaxis": {"title": f"Flux [{alternate_flux_unit}]"},
+                            },
+                        ],
+                    },
+                ],
+                "direction": "left",
+                "pad": {"r": 10, "t": 10},
+                "showactive": True,
+                "type": "buttons",
+                "x": 0.5,
+                "xanchor": "center",
+                "y": 1.15,
+                "yanchor": "top",
+            }
+        ],
+    )
+
+    return fig
+
+
+def render_viewer_html(
+    spectrum: Spectrum1D,
+    *,
+    metadata: Iterable[JWSTProductMetadata],
+    header_metadata: Dict[str, Optional[str]],
+    output_path: Optional[Path] = None,
+) -> str:
+    """Render the spectrum and metadata into a standalone HTML document."""
+
+    figure = _build_figure(spectrum)
+    figure_json = json.dumps(figure, cls=PlotlyJSONEncoder)
+    metadata_rows = _format_metadata_items(metadata)
+
+    provenance_rows = "".join(
+        f"""
+        <tr>
+            <td>{key}</td>
+            <td>{value or ""}</td>
+        </tr>
+        """
+        for key, value in header_metadata.items()
+    )
+
+    obs_rows = "".join(
+        f"""
+        <tr>
+            <td>{row['Observation ID']}</td>
+            <td>{row['Program ID']}</td>
+            <td>{row['Instrument']}</td>
+            <td>{row['Target']}</td>
+            <td>{row['PI'] or ''}</td>
+            <td>{row['Collection']}</td>
+            <td><a href='{row['Download']}' target='_blank' rel='noopener'>{row['Download']}</a></td>
+        </tr>
+        """
+        for row in metadata_rows
+    )
+
+    html = f"""
+<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <title>JWST Spectrum Viewer</title>
+  <script src=\"https://cdn.plot.ly/plotly-latest.min.js\"></script>
+  <style>
+    body {{ font-family: sans-serif; margin: 0; padding: 0; background: #10141a; color: #edf2ff; }}
+    header {{ padding: 1rem 2rem; background: #1f2a36; }}
+    main {{ padding: 2rem; }}
+    section {{ margin-bottom: 2rem; background: #16202b; padding: 1.5rem; border-radius: 8px; }}
+    table {{ width: 100%; border-collapse: collapse; }}
+    th, td {{ border: 1px solid #2a3848; padding: 0.5rem; text-align: left; }}
+    th {{ background: #243244; }}
+    a {{ color: #8bbfff; }}
+    .panel-title {{ margin-top: 0; }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>JWST Spectral Explorer</h1>
+  </header>
+  <main>
+    <section>
+      <div id=\"jwst-spectrum\"></div>
+    </section>
+    <section>
+      <h2 class=\"panel-title\">Citations / Provenance</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {provenance_rows}
+        </tbody>
+      </table>
+    </section>
+    <section>
+      <h2 class=\"panel-title\">Mission &amp; Instrument Details</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Observation ID</th>
+            <th>Program ID</th>
+            <th>Instrument</th>
+            <th>Target</th>
+            <th>PI</th>
+            <th>Collection</th>
+            <th>Download</th>
+          </tr>
+        </thead>
+        <tbody>
+          {obs_rows}
+        </tbody>
+      </table>
+    </section>
+  </main>
+  <script>
+    const figureSpec = {figure_json};
+    Plotly.newPlot('jwst-spectrum', figureSpec.data, figureSpec.layout, {{responsive: true}});
+  </script>
+</body>
+</html>
+"""
+
+    if output_path:
+        Path(output_path).write_text(html, encoding="utf-8")
+    return html


### PR DESCRIPTION
## Summary
- add a src-based `jwst_viewer` package with MAST discovery, spectrum parsing, and Plotly viewer modules
- wire the CLI entry point to download JWST Level-2 spectra, convert units safely, and render provenance metadata
- document new workflow and dependencies for the interactive spectral explorer

## Testing
- PYTHONPATH=src python -m jwst_viewer --help

------
https://chatgpt.com/codex/tasks/task_e_68d725b595d48329b77a1c667ccd5e2d