### PR TITLE
Handle preferred flux unit conversion with spectral density equivalencies

### DIFF
--- a/src/jwst_viewer/spectrum_loader.py
+++ b/src/jwst_viewer/spectrum_loader.py
@@ -53,11 +53,13 @@ class JWSTSpectrumLoader:
         original_spectral_axis_values = np.array(spectrum.spectral_axis.value, copy=True)
 
         converted = spectrum
-        spectral_equivalencies = None
+        spectral_equivalencies = u.spectral_density(spectrum.spectral_axis)
         if spectrum.flux.unit != self.preferred_flux_unit:
-            spectral_equivalencies = u.spectral_density(spectrum.spectral_axis)
-            converted = converted.to(
-                unit=self.preferred_flux_unit, equivalencies=spectral_equivalencies
+            converted = Spectrum1D(
+                flux=spectrum.flux.to(
+                    self.preferred_flux_unit, equivalencies=spectral_equivalencies
+                ),
+                spectral_axis=spectrum.spectral_axis,
             )
         if spectrum.spectral_axis.unit != self.preferred_wave_unit:
             converted = Spectrum1D(


### PR DESCRIPTION
## Summary
- compute the spectral density equivalencies up front when applying preferred units in the loader
- convert flux values with Spectrum1D while preserving the existing spectral axis conversion logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d72f7b37048329b8202b1ee1cf43e2