### PR TITLE
Allow target-only JWST viewer queries

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -8,6 +8,9 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
 - _Iteration:_ Initial JWST viewer build
   - _Summary:_ Added a modular JWST spectral viewer package with MAST discovery, Specutils-based parsing, Plotly interactivity, and provenance surfacing wired into the CLI entry point.
   - _Related Issues / Tickets:_ N/A
+- _Iteration:_ Optional program/target discovery
+  - _Summary:_ Allowed the CLI to resolve spectra via either program ID or target name and documented the name-based search workflow.
+  - _Related Issues / Tickets:_ N/A
 
 ## Documentation URLs Consulted
 - _Iteration:_ Initial JWST viewer build
@@ -17,6 +20,9 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
     - https://astroquery.readthedocs.io/en/latest/mast/mast.html#observation-products
     - https://mast.stsci.edu/api/v0/pyex.html
     - https://specutils.readthedocs.io/en/stable/spectrum1d.html#reading-from-files
+- _Iteration:_ Optional program/target discovery
+  - _Authoritative Source:_ `Training Documents/Reference Links for app v3.docx`
+  - _Additional References:_ N/A
 
 ## Parsed Data Fields with Provenance
 - _Iteration:_ Initial JWST viewer build
@@ -25,8 +31,15 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
   - _Usage:_ Displayed within the Mission & Instrument panel for provenance and linking back to MAST resources.
   - _Field:_ FITS header metadata (telescope, instrument, program, observation, visit, target, pipeline version).
   - _Usage:_ Rendered in the Citations / Provenance panel to expose product lineage and calibration context.
+- _Iteration:_ Optional program/target discovery
+  - _Source:_ Existing MAST metadata fields; no new data fields introduced.
+  - _Field:_ N/A
+  - _Usage:_ N/A
 
 ## Validation Steps
 - _Iteration:_ Initial JWST viewer build
   - _Checks Performed:_ `PYTHONPATH=src python -m jwst_viewer --help`
   - _Command Output / Evidence:_ Help text rendered confirming CLI wiring.
+- _Iteration:_ Optional program/target discovery
+  - _Checks Performed:_ `PYTHONPATH=src python -m jwst_viewer --help`
+  - _Command Output / Evidence:_ Help text now advertises optional program ID and target-based search path.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ Each time you add or modify functionality:
 3. Update the parsed data fields section with every new or modified field, including its provenance and usage.
 4. Document the commands or tests executed to validate the work, along with any pertinent output or evidence.
 5. Commit the updates to `IMPLEMENTATION_NOTES.md` alongside the code changes so the history remains synchronized with project development.
+
+## Command Line Usage
+
+The JWST spectral viewer can discover products by program identifier or by target name:
+
+- `python -m jwst_viewer 2730` — fetches spectra for program **2730** using the proposal identifier.
+- `python -m jwst_viewer --target "WASP-39"` — performs a name-based search, which is useful when the program ID is unknown.
+- Both arguments may be combined to further constrain results: `python -m jwst_viewer 2730 --target "WASP-39"`.
+
+At least one of the program identifier or `--target` flag must be supplied before the tool will query MAST.


### PR DESCRIPTION
## Summary
- allow the CLI program ID argument to be optional and validate that either a program ID or --target is supplied
- ensure JWST product discovery passes None when either identifier is omitted and expand error/help messaging for name-based searches
- document the name-based discovery workflow in the README and implementation notes

## Testing
- PYTHONPATH=src python -m jwst_viewer --help

------
https://chatgpt.com/codex/tasks/task_e_68d731f0554483298acd1d42a9bbff8e