### PR TITLE
Add quick plotting control to viewer search

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -14,6 +14,9 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
 - _Iteration:_ Multi-product viewer enhancements
   - _Summary:_ Embedded mission metadata within the HTML output, added target filtering controls, and enabled Plotly trace toggling for multiple spectra loaded via the CLI.
   - _Related Issues / Tickets:_ N/A
+- _Iteration:_ Search-driven quick plotting
+  - _Summary:_ Added an "Add first match" control (and Enter-key shortcut) that filters mission metadata and plots the first visible spectrum directly from the search box.
+  - _Related Issues / Tickets:_ N/A
 
 ## Documentation URLs Consulted
 - _Iteration:_ Initial JWST viewer build
@@ -30,6 +33,9 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
   - _Authoritative Source:_ `Training Documents/Reference Links for app v3.docx`
   - _Additional References:_
     - https://astroquery.readthedocs.io/en/latest/mast/mast_obsquery.html
+- _Iteration:_ Search-driven quick plotting
+  - _Authoritative Source:_ `Training Documents/Reference Links for app v3.docx`
+  - _Additional References:_ N/A
 
 ## Parsed Data Fields with Provenance
 - _Iteration:_ Initial JWST viewer build
@@ -57,3 +63,6 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
 - _Iteration:_ Multi-product viewer enhancements
   - _Checks Performed:_ `PYTHONPATH=src python -m jwst_viewer --help`
   - _Command Output / Evidence:_ CLI help confirms the entry point remains available after multi-spectrum wiring.
+- _Iteration:_ Search-driven quick plotting
+  - _Checks Performed:_ `PYTHONPATH=src python -m jwst_viewer --help`
+  - _Command Output / Evidence:_ Help text continues to render after wiring the new HTML search controls.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ The JWST spectral viewer can discover products by program identifier or by targe
 - Both arguments may be combined to further constrain results: `python -m jwst_viewer 2730 --target "WASP-39"`.
 
 At least one of the program identifier or `--target` flag must be supplied before the tool will query MAST.
+
+Within the generated HTML viewer you can narrow the Mission & Instrument table using the target filter and quickly plot the top-matching spectrum by pressing **Enter** or clicking the **Add first match** button.


### PR DESCRIPTION
## Summary
- add a dedicated "Add first match" control and Enter-key shortcut to the metadata search UI
- wire the client script to add the first visible spectrum and show contextual feedback
- document the quicker search-and-plot gesture in the README and implementation notes

## Testing
- PYTHONPATH=src python -m jwst_viewer --help

------
https://chatgpt.com/codex/tasks/task_e_68d736daca008329b4cf0b22a5b8d402