### PR TITLE
Add fallback for JWST target search mismatch

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -17,6 +17,9 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
 - _Iteration:_ Search-driven quick plotting
   - _Summary:_ Added an "Add first match" control (and Enter-key shortcut) that filters mission metadata and plots the first visible spectrum directly from the search box.
   - _Related Issues / Tickets:_ N/A
+- _Iteration:_ Program/target fallback search
+  - _Summary:_ Logged and surfaced CLI warnings when an exact target/program match fails, then re-ran discovery with a relaxed target constraint so downloads can proceed when canonical names differ.
+  - _Related Issues / Tickets:_ N/A
 
 ## Documentation URLs Consulted
 - _Iteration:_ Initial JWST viewer build
@@ -36,6 +39,10 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
 - _Iteration:_ Search-driven quick plotting
   - _Authoritative Source:_ `Training Documents/Reference Links for app v3.docx`
   - _Additional References:_ N/A
+- _Iteration:_ Program/target fallback search
+  - _Authoritative Source:_ `Training Documents/Reference Links for app v3.docx`
+  - _Additional References:_
+    - https://mast.stsci.edu/portal/Mashup/Clients/Mast/Portal.html
 
 ## Parsed Data Fields with Provenance
 - _Iteration:_ Initial JWST viewer build
@@ -52,6 +59,10 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
   - _Source:_ MAST observation/product metadata returned by the Observations service and serialized Specutils spectra arrays.
   - _Field:_ Observation metadata augmented with spectrum identifiers for UI filtering and Plotly trace wiring.
   - _Usage:_ Drives the mission table search results and associates checkboxes with serialized spectra traces in the HTML payload.
+- _Iteration:_ Program/target fallback search
+  - _Source:_ N/A (no new data fields introduced; the change relaxes discovery queries only when necessary).
+  - _Field:_ N/A
+  - _Usage:_ N/A
 
 ## Validation Steps
 - _Iteration:_ Initial JWST viewer build
@@ -66,3 +77,6 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
 - _Iteration:_ Search-driven quick plotting
   - _Checks Performed:_ `PYTHONPATH=src python -m jwst_viewer --help`
   - _Command Output / Evidence:_ Help text continues to render after wiring the new HTML search controls.
+- _Iteration:_ Program/target fallback search
+  - _Checks Performed:_ `PYTHONPATH=src python -m jwst_viewer --help`
+  - _Command Output / Evidence:_ Help text prints successfully after surfacing relaxed-search warnings.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,16 @@ Each time you add or modify functionality:
 
 ## Command Line Usage
 
-The JWST spectral viewer can discover products by program identifier or by target name:
+The JWST spectral viewer can discover products by program identifier or by target name. Target names must match the canonical
+labels published in the [MAST Portal target resolver](https://mast.stsci.edu/portal/Mashup/Clients/Mast/Portal.html); MAST's
+Observations service only honors exact matches when both program ID and target are provided in the same query.
 
 - `python -m jwst_viewer 2730` — fetches spectra for program **2730** using the proposal identifier.
 - `python -m jwst_viewer --target "WASP-39"` — performs a name-based search, which is useful when the program ID is unknown.
 - Both arguments may be combined to further constrain results: `python -m jwst_viewer 2730 --target "WASP-39"`.
+
+If an exact target/program pair returns no spectra, the CLI broadens the search to the entire program, warns about the relaxed
+filter, and continues with any matching products.
 
 At least one of the program identifier or `--target` flag must be supplied before the tool will query MAST.
 

--- a/src/jwst_viewer/__main__.py
+++ b/src/jwst_viewer/__main__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -84,6 +85,9 @@ def main(argv: Optional[list[str]] = None) -> None:
         instrument_name=args.instrument,
         target_name=args.target if args.target else None,
     )
+
+    if client.last_query_relaxed_message:
+        print(f"WARNING: {client.last_query_relaxed_message}", file=sys.stderr)
 
     if not paths:
         parser.error(


### PR DESCRIPTION
## Summary
- add logging-backed fallback in the MAST client when an exact target/program query returns no observations
- warn CLI users when the relaxed search results are used and document the behavior for the command line workflow
- record the canonical target name requirement and relaxed-search behavior in the README and implementation notes

## Testing
- PYTHONPATH=src python -m jwst_viewer --help

------
https://chatgpt.com/codex/tasks/task_e_68d73b6b14fc8329a1a48aaca01e033a