### PR TITLE
Handle relaxed JWST target-only discovery flows

### DIFF
--- a/src/jwst_viewer/mast_client.py
+++ b/src/jwst_viewer/mast_client.py
@@ -190,6 +190,69 @@ class JWSTMastClient:
                     "Relaxed JWST search for program %s still returned no observations.",
                     program_id,
                 )
+        elif len(observations) == 0 and target_name and not program_id:
+            relaxed_message = (
+                "Exact target match '%s' returned no JWST observations; "
+                "broadening the search using wildcard and positional lookups."
+            )
+            message = relaxed_message % target_name
+            logger.warning(message)
+            self._last_query_relaxed_message = message
+
+            wildcard_target = f"{target_name}*"
+            observations = self.discover_observations(
+                target_name=wildcard_target,
+                instrument_name=instrument_name,
+                filters=filters,
+            )
+            if len(observations) == 0:
+                logger.warning(
+                    "Wildcard JWST search for target '%s' returned no observations; "
+                    "attempting positional lookup.",
+                    target_name,
+                )
+                try:
+                    broader_results = Observations.query_object(
+                        target_name, radius="0d0m30s"
+                    )
+                except Exception as exc:  # pragma: no cover - remote lookup guard
+                    logger.warning(
+                        "Positional lookup for target '%s' failed: %s", target_name, exc
+                    )
+                    broader_results = Table()
+
+                filtered_results = broader_results
+                if len(filtered_results) and "obs_collection" in filtered_results.colnames:
+                    filtered_results = filtered_results[
+                        filtered_results["obs_collection"] == "JWST"
+                    ]
+                if len(filtered_results) and "dataproduct_type" in filtered_results.colnames:
+                    filtered_results = filtered_results[
+                        filtered_results["dataproduct_type"] == "spectrum"
+                    ]
+                if instrument_name and "instrument_name" in filtered_results.colnames:
+                    filtered_results = filtered_results[
+                        filtered_results["instrument_name"] == instrument_name
+                    ]
+                if filters and len(filtered_results):
+                    for key, value in filters.items():
+                        if key not in filtered_results.colnames:
+                            continue
+                        if isinstance(value, (list, tuple, set)):
+                            allowed = set(value)
+                            mask = [entry in allowed for entry in filtered_results[key]]
+                            filtered_results = filtered_results[mask]
+                        else:
+                            filtered_results = filtered_results[
+                                filtered_results[key] == value
+                            ]
+
+                observations = filtered_results
+                if len(observations) == 0:
+                    logger.warning(
+                        "Relaxed JWST search for target '%s' still returned no observations.",
+                        target_name,
+                    )
         products = self.discover_products(observations)
         downloaded_paths = self.download_products(products, mrp_only=mrp_only, cache=cache)
         metadata = self.collect_metadata(observations, products, downloaded_paths)

--- a/src/jwst_viewer/webapp.py
+++ b/src/jwst_viewer/webapp.py
@@ -97,6 +97,7 @@ def _render_shell() -> str:
           <button type=\"submit\">Fetch spectra</button>
         </form>
         <p id=\"search-status\" class=\"status\"></p>
+        <p id=\"search-warning\" class=\"status hidden\"></p>
       </section>
       <section>
         <div class=\"unit-toggle\">
@@ -147,6 +148,7 @@ def _render_shell() -> str:
       const form = document.getElementById('search-form');
       const status = document.getElementById('search-status');
       const tableStatus = document.getElementById('table-status');
+      const warningBanner = document.getElementById('search-warning');
       const metadataBody = document.getElementById('metadata-body');
       const provenanceBody = document.getElementById('provenance-body');
       const unitSelect = document.getElementById('unit-mode');
@@ -167,6 +169,8 @@ def _render_shell() -> str:
 
         status.textContent = 'Fetching spectra…';
         tableStatus.textContent = '';
+        warningBanner.textContent = '';
+        warningBanner.classList.add('hidden');
         provenanceBody.innerHTML = '';
         metadataBody.innerHTML = '';
         unitSelect.disabled = true;
@@ -190,10 +194,17 @@ def _render_shell() -> str:
           }
           const payload = await response.json();
           handlePayload(payload);
-          status.textContent = `Loaded ${payload.spectra.length} spectra.`;
+          const loadedCount = (payload.spectra || []).length;
+          status.textContent = `Loaded ${loadedCount} spectra.`;
+          if (payload.warning) {
+            warningBanner.textContent = payload.warning;
+            warningBanner.classList.remove('hidden');
+          }
         } catch (error) {
           console.error(error);
           status.textContent = error.message || 'Failed to fetch spectra.';
+          warningBanner.textContent = '';
+          warningBanner.classList.add('hidden');
         }
       });
 

--- a/tests/test_mast_client.py
+++ b/tests/test_mast_client.py
@@ -1,0 +1,116 @@
+"""Tests for the JWST MAST client discovery workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Iterable, List
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from astropy.table import Table
+
+from jwst_viewer import mast_client
+from jwst_viewer.mast_client import JWSTMastClient
+
+
+def _make_dummy_observations(
+    query_returns: Iterable[Table], query_object_return: Table | None = None
+):
+    """Return a dummy :class:`Observations` stand-in with recorded calls."""
+
+    query_return_list = list(query_returns)
+    object_return = query_object_return or Table()
+
+    class DummyObservations:
+        query_returns: List[Table] = query_return_list
+        query_calls: List[dict] = []
+        query_object_calls: List[tuple] = []
+        query_object_return: Table = object_return
+
+        @classmethod
+        def query_criteria(cls, **kwargs):
+            cls.query_calls.append(kwargs)
+            if cls.query_returns:
+                return cls.query_returns.pop(0)
+            return Table()
+
+        @classmethod
+        def query_object(cls, *args, **kwargs):
+            cls.query_object_calls.append((args, kwargs))
+            return cls.query_object_return
+
+        @staticmethod
+        def get_product_list(observations):
+            return Table()
+
+        @staticmethod
+        def filter_products(*args, **kwargs):
+            return Table()
+
+        @staticmethod
+        def download_products(*args, **kwargs):
+            return None
+
+    return DummyObservations
+
+
+def test_target_relax_wildcard(monkeypatch, tmp_path):
+    """Target-only searches should retry with wildcard matching."""
+
+    wildcard_results = Table(
+        names=["obsid", "target_name"],
+        rows=[(123, "Test Target Extended")],
+    )
+    dummy = _make_dummy_observations([Table(), wildcard_results])
+    monkeypatch.setattr(mast_client, "Observations", dummy)
+
+    client = JWSTMastClient(download_dir=tmp_path)
+    observations, products, paths, metadata = client.discover_and_download(
+        target_name="Test Target"
+    )
+
+    assert len(observations) == 1
+    assert not len(products)
+    assert not paths
+    assert not metadata
+    assert dummy.query_calls[0]["target_name"] == "Test Target"
+    assert dummy.query_calls[1]["target_name"] == "Test Target*"
+    assert client.last_query_relaxed_message is not None
+
+
+def test_target_relax_object_lookup(monkeypatch, tmp_path):
+    """When wildcard fails, the client should fall back to a positional lookup."""
+
+    positional_results = Table(
+        names=[
+            "obsid",
+            "obs_collection",
+            "dataproduct_type",
+            "instrument_name",
+            "intentType",
+            "target_name",
+        ],
+        rows=[
+            (10, "JWST", "spectrum", "NIRSpec", "SCIENCE", "Target A"),
+            (11, "HST", "spectrum", "NIRSpec", "SCIENCE", "Target A"),
+            (12, "JWST", "image", "NIRSpec", "SCIENCE", "Target A"),
+            (13, "JWST", "spectrum", "MIRI", "SCIENCE", "Target A"),
+            (14, "JWST", "spectrum", "NIRSpec", "CALIBRATION", "Target A"),
+        ],
+    )
+    dummy = _make_dummy_observations([Table(), Table()], positional_results)
+    monkeypatch.setattr(mast_client, "Observations", dummy)
+
+    client = JWSTMastClient(download_dir=tmp_path)
+    observations, products, paths, metadata = client.discover_and_download(
+        target_name="Target A",
+        instrument_name="NIRSpec",
+        filters={"intentType": ["SCIENCE"]},
+    )
+
+    assert len(observations) == 1
+    assert observations[0]["obsid"] == 10
+    assert dummy.query_object_calls
+    assert client.last_query_relaxed_message is not None
+


### PR DESCRIPTION
## Summary
- broaden target-only discovery by retrying with wildcard and positional lookups and capture the corresponding warning
- surface discovery warnings in the /api/spectra response and display them in the search shell
- add regression tests for wildcard and positional discovery fallbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d74a9d5e208329867721345812afb7