### PR TITLE
feat: add FastAPI JWST web explorer

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -20,6 +20,12 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
 - _Iteration:_ Program/target fallback search
   - _Summary:_ Logged and surfaced CLI warnings when an exact target/program match fails, then re-ran discovery with a relaxed target constraint so downloads can proceed when canonical names differ.
   - _Related Issues / Tickets:_ N/A
+- _Iteration:_ FastAPI web interface
+  - _Summary:_ Added a persistent FastAPI-powered site that exposes search controls for JWST spectra, reuses the Plotly viewer payloads, and responds with interactive metadata and provenance without regenerating static HTML.
+  - _Related Issues / Tickets:_ N/A
+- _Iteration:_ MAST resilience updates
+  - _Summary:_ Hardened the MAST discovery pipeline against transient outages and broadened target-only searches via cone lookups so star-name queries surface spectra when exact matches fail.
+  - _Related Issues / Tickets:_ N/A
 
 ## Documentation URLs Consulted
 - _Iteration:_ Initial JWST viewer build
@@ -43,6 +49,15 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
   - _Authoritative Source:_ `Training Documents/Reference Links for app v3.docx`
   - _Additional References:_
     - https://mast.stsci.edu/portal/Mashup/Clients/Mast/Portal.html
+- _Iteration:_ FastAPI web interface
+  - _Authoritative Source:_ `Training Documents/Reference Links for app v3.docx`
+  - _Additional References:_
+    - https://astroquery.readthedocs.io/en/latest/mast/mast_obsquery.html
+    - https://specutils.readthedocs.io/en/stable/spectrum1d.html
+- _Iteration:_ MAST resilience updates
+  - _Authoritative Source:_ `Training Documents/Reference Links for app v3.docx`
+  - _Additional References:_
+    - https://astroquery.readthedocs.io/en/latest/mast/mast_obsquery.html
 
 ## Parsed Data Fields with Provenance
 - _Iteration:_ Initial JWST viewer build
@@ -63,6 +78,14 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
   - _Source:_ N/A (no new data fields introduced; the change relaxes discovery queries only when necessary).
   - _Field:_ N/A
   - _Usage:_ N/A
+- _Iteration:_ FastAPI web interface
+  - _Source:_ MAST observations/product metadata plus JWST FITS headers parsed through the Specutils loader.
+  - _Field:_ Same provenance fields as the CLI viewer, now serialized through the API for the browser shell.
+  - _Usage:_ Returned via the `/api/spectra` endpoint to populate the mission table and provenance panel dynamically.
+- _Iteration:_ MAST resilience updates
+  - _Source:_ Existing MAST observation/product metadata returned by relaxed cone-search discovery.
+  - _Field:_ No new fields; the change preserves previous provenance data while ensuring broader target search coverage.
+  - _Usage:_ Allows the UI to populate existing panels when spectra are located via the fallback discovery path.
 
 ## Validation Steps
 - _Iteration:_ Initial JWST viewer build
@@ -80,3 +103,9 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
 - _Iteration:_ Program/target fallback search
   - _Checks Performed:_ `PYTHONPATH=src python -m jwst_viewer --help`
   - _Command Output / Evidence:_ Help text prints successfully after surfacing relaxed-search warnings.
+- _Iteration:_ FastAPI web interface
+  - _Checks Performed:_ `PYTHONPATH=src python -m jwst_viewer.webapp --host 127.0.0.1 --port 8000 --help`
+  - _Command Output / Evidence:_ FastAPI launcher arguments render, confirming the server entry point.
+- _Iteration:_ MAST resilience updates
+  - _Checks Performed:_ `pytest`
+  - _Command Output / Evidence:_ Test suite passes, confirming spectrum conversions remain stable after the discovery updates.

--- a/README.md
+++ b/README.md
@@ -28,3 +28,13 @@ filter, and continues with any matching products.
 At least one of the program identifier or `--target` flag must be supplied before the tool will query MAST.
 
 Within the generated HTML viewer you can narrow the Mission & Instrument table using the target filter and quickly plot the top-matching spectrum by pressing **Enter** or clicking the **Add first match** button.
+
+## Browser-based Explorer
+
+Launch a persistent web experience with:
+
+```
+python -m jwst_viewer.webapp --host 127.0.0.1 --port 8000
+```
+
+The site serves an interactive search form so you can query by program ID or target name without regenerating HTML files. Submit the form to fetch spectra, toggle between unit systems, review provenance, and add or remove traces directly from the page.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ dependencies = [
   "astropy>=6.0",
   "specutils>=1.14",
   "plotly>=5.20",
+  "fastapi>=0.110",
+  "uvicorn>=0.27",
 ]
 
 [build-system]

--- a/src/jwst_viewer/webapp.py
+++ b/src/jwst_viewer/webapp.py
@@ -1,0 +1,454 @@
+"""FastAPI web application for the JWST spectral viewer."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, Optional
+
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.responses import HTMLResponse
+import uvicorn
+
+from astropy import units as u
+from specutils import Spectrum1D  # type: ignore
+
+from .mast_client import JWSTMastClient, JWSTDiscoveryError
+from .spectrum_loader import JWSTSpectrumLoader
+from .viewer import build_viewer_payload
+
+APP = FastAPI(title="JWST Spectral Explorer")
+
+
+def _build_client(download_dir: Path) -> JWSTMastClient:
+    """Instantiate a MAST client rooted at ``download_dir``.
+
+    The discovery call follows the observations query guidance in the Astroquery
+    docs.  See https://astroquery.readthedocs.io/en/latest/mast/mast_obsquery.html
+    for the documented parameters and workflow.
+    """
+
+    return JWSTMastClient(download_dir=str(download_dir))
+
+
+def _build_loader(flux_unit: u.Unit, wave_unit: u.Unit) -> JWSTSpectrumLoader:
+    """Create a loader configured for the preferred units documented by Specutils.
+
+    Specutils unit handling guidance lives at
+    https://specutils.readthedocs.io/en/stable/spectrum1d.html which documents
+    the preferred ``Spectrum1D`` APIs for conversions.
+    """
+
+    return JWSTSpectrumLoader(preferred_flux_unit=flux_unit, preferred_wave_unit=wave_unit)
+
+
+def _render_shell() -> str:
+    """Return the static HTML shell for the interactive viewer."""
+
+    return """
+<!DOCTYPE html>
+<html lang=\"en\">
+  <head>
+    <meta charset=\"utf-8\" />
+    <title>JWST Spectral Explorer</title>
+    <script src=\"https://cdn.plot.ly/plotly-latest.min.js\"></script>
+    <style>
+      body { font-family: sans-serif; margin: 0; padding: 0; background: #10141a; color: #edf2ff; }
+      header { padding: 1rem 2rem; background: #1f2a36; }
+      main { padding: 2rem; display: grid; gap: 1.5rem; }
+      section { background: #16202b; padding: 1.5rem; border-radius: 8px; }
+      form { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; align-items: flex-end; }
+      label { display: flex; flex-direction: column; font-weight: 600; gap: 0.4rem; }
+      input, select { padding: 0.5rem; border-radius: 4px; border: 1px solid #2a3848; background: #10141a; color: #edf2ff; }
+      button { padding: 0.55rem 0.9rem; border-radius: 4px; border: 1px solid #2a3848; background: #243244; color: #edf2ff; font-weight: 600; cursor: pointer; }
+      button:hover { background: #2f4054; }
+      .panel-title { margin-top: 0; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { border: 1px solid #2a3848; padding: 0.45rem; text-align: left; }
+      th { background: #243244; }
+      a { color: #8bbfff; }
+      .checkbox-cell { text-align: center; }
+      .status { min-height: 1.5rem; font-size: 0.95rem; color: #8bbfff; }
+      .hidden { display: none; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>JWST Spectral Explorer</h1>
+    </header>
+    <main>
+      <section>
+        <h2 class=\"panel-title\">Search JWST Spectra</h2>
+        <form id=\"search-form\">
+          <label>Program ID
+            <input type=\"text\" id=\"program-id\" placeholder=\"e.g. 2730\" />
+          </label>
+          <label>Target name
+            <input type=\"text\" id=\"target-name\" placeholder=\"e.g. WASP-39b\" />
+          </label>
+          <label>Instrument
+            <input type=\"text\" id=\"instrument-name\" placeholder=\"Optional\" />
+          </label>
+          <label>Flux unit
+            <input type=\"text\" id=\"flux-unit\" value=\"Jy\" />
+          </label>
+          <label>Wave unit
+            <input type=\"text\" id=\"wave-unit\" value=\"micron\" />
+          </label>
+          <button type=\"submit\">Fetch spectra</button>
+        </form>
+        <p id=\"search-status\" class=\"status\"></p>
+      </section>
+      <section>
+        <div class=\"unit-toggle\">
+          <label for=\"unit-mode\">Display units:</label>
+          <select id=\"unit-mode\" disabled>
+            <option value=\"primary\">Preferred</option>
+            <option value=\"alternate\">Alternate</option>
+          </select>
+        </div>
+        <div id=\"jwst-spectrum\"></div>
+      </section>
+      <section>
+        <h2 class=\"panel-title\">Citations / Provenance</h2>
+        <table>
+          <thead>
+            <tr><th>Field</th><th>Value</th></tr>
+          </thead>
+          <tbody id=\"provenance-body\"></tbody>
+        </table>
+      </section>
+      <section>
+        <h2 class=\"panel-title\">Mission &amp; Instrument Details</h2>
+        <p id=\"table-status\" class=\"status\"></p>
+        <table>
+          <thead>
+            <tr>
+              <th>Observation ID</th>
+              <th>Program ID</th>
+              <th>Instrument</th>
+              <th>Target</th>
+              <th>PI</th>
+              <th>Collection</th>
+              <th>Download</th>
+              <th>Select</th>
+            </tr>
+          </thead>
+          <tbody id=\"metadata-body\"></tbody>
+        </table>
+      </section>
+    </main>
+    <script>
+      let spectraPayload = [];
+      const spectraById = new Map();
+      const traceRegistry = new Map();
+      let currentUnitMode = 'primary';
+      let primarySpectrumId = null;
+
+      const form = document.getElementById('search-form');
+      const status = document.getElementById('search-status');
+      const tableStatus = document.getElementById('table-status');
+      const metadataBody = document.getElementById('metadata-body');
+      const provenanceBody = document.getElementById('provenance-body');
+      const unitSelect = document.getElementById('unit-mode');
+      const plotElement = document.getElementById('jwst-spectrum');
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const programId = document.getElementById('program-id').value.trim();
+        const targetName = document.getElementById('target-name').value.trim();
+        const instrumentName = document.getElementById('instrument-name').value.trim();
+        const fluxUnit = document.getElementById('flux-unit').value.trim() || 'Jy';
+        const waveUnit = document.getElementById('wave-unit').value.trim() || 'micron';
+
+        if (!programId && !targetName) {
+          status.textContent = 'Provide a program ID or target name.';
+          return;
+        }
+
+        status.textContent = 'Fetching spectra…';
+        tableStatus.textContent = '';
+        provenanceBody.innerHTML = '';
+        metadataBody.innerHTML = '';
+        unitSelect.disabled = true;
+        spectraPayload = [];
+        spectraById.clear();
+        traceRegistry.clear();
+        Plotly.purge(plotElement);
+
+        const params = new URLSearchParams();
+        if (programId) params.set('program_id', programId);
+        if (targetName) params.set('target', targetName);
+        if (instrumentName) params.set('instrument', instrumentName);
+        params.set('flux_unit', fluxUnit);
+        params.set('wave_unit', waveUnit);
+
+        try {
+          const response = await fetch(`/api/spectra?${params.toString()}`);
+          if (!response.ok) {
+            const detail = await response.json();
+            throw new Error(detail.detail || 'Unable to fetch spectra.');
+          }
+          const payload = await response.json();
+          handlePayload(payload);
+          status.textContent = `Loaded ${payload.spectra.length} spectra.`;
+        } catch (error) {
+          console.error(error);
+          status.textContent = error.message || 'Failed to fetch spectra.';
+        }
+      });
+
+      unitSelect.addEventListener('change', (event) => {
+        const mode = event.target.value === 'alternate' ? 'alternate' : 'primary';
+        setUnitMode(mode);
+      });
+
+      function handlePayload(payload) {
+        spectraPayload = payload.spectra || [];
+        primarySpectrumId = payload.primary_spectrum_id || null;
+        spectraById.clear();
+        spectraPayload.forEach((item) => spectraById.set(item.id, item));
+
+        populateProvenance(payload.provenance_html || '');
+        populateMetadata(payload.metadata || []);
+        Plotly.newPlot('jwst-spectrum', payload.figure.data, payload.figure.layout, {responsive: true}).then(() => {
+          traceRegistry.clear();
+          if (primarySpectrumId && spectraById.has(primarySpectrumId)) {
+            traceRegistry.set(primarySpectrumId, 0);
+          }
+          unitSelect.disabled = false;
+          unitSelect.value = 'primary';
+          currentUnitMode = 'primary';
+        });
+      }
+
+      function populateProvenance(html) {
+        provenanceBody.innerHTML = html || '';
+      }
+
+      function populateMetadata(records) {
+        metadataBody.innerHTML = '';
+        if (!records || records.length === 0) {
+          tableStatus.textContent = 'No observations available for the supplied criteria.';
+          return;
+        }
+        tableStatus.textContent = '';
+        records.forEach((record) => {
+          const row = document.createElement('tr');
+          row.dataset.spectrumId = record['spectrum_id'] || '';
+          addCell(row, record['Observation ID']);
+          addCell(row, record['Program ID']);
+          addCell(row, record['Instrument']);
+          addCell(row, record['Target']);
+          addCell(row, record['PI'] || '');
+          addCell(row, record['Collection']);
+          addLinkCell(row, record['Download']);
+          addCheckboxCell(row, record['spectrum_id']);
+          metadataBody.appendChild(row);
+        });
+      }
+
+      function addCell(row, value) {
+        const cell = document.createElement('td');
+        cell.textContent = value == null ? '' : value;
+        row.appendChild(cell);
+      }
+
+      function addLinkCell(row, value) {
+        const cell = document.createElement('td');
+        if (value && value.href) {
+          const link = document.createElement('a');
+          link.href = value.href;
+          link.target = '_blank';
+          link.rel = 'noopener';
+          link.textContent = value.label || 'Download';
+          cell.appendChild(link);
+        }
+        row.appendChild(cell);
+      }
+
+      function addCheckboxCell(row, spectrumId) {
+        const cell = document.createElement('td');
+        cell.classList.add('checkbox-cell');
+        if (spectrumId && spectraById.has(spectrumId)) {
+          const checkbox = document.createElement('input');
+          checkbox.type = 'checkbox';
+          checkbox.checked = traceRegistry.has(spectrumId);
+          checkbox.addEventListener('change', () => {
+            if (checkbox.checked) {
+              addSpectrumTrace(spectrumId);
+            } else {
+              removeSpectrumTrace(spectrumId);
+            }
+          });
+          cell.appendChild(checkbox);
+        } else {
+          cell.textContent = '—';
+        }
+        row.appendChild(cell);
+      }
+
+      function addSpectrumTrace(spectrumId) {
+        if (traceRegistry.has(spectrumId)) {
+          return;
+        }
+        const payload = spectraById.get(spectrumId);
+        if (!payload) {
+          return;
+        }
+        const data = payload[currentUnitMode];
+        Plotly.addTraces(plotElement, {
+          x: data.x,
+          y: data.y,
+          mode: 'lines',
+          name: data.trace_name,
+        }).then((indices) => {
+          traceRegistry.set(spectrumId, indices[0]);
+        });
+      }
+
+      function removeSpectrumTrace(spectrumId) {
+        const index = traceRegistry.get(spectrumId);
+        if (index == null) {
+          return;
+        }
+        Plotly.deleteTraces(plotElement, [index]).then(() => {
+          traceRegistry.delete(spectrumId);
+          const entries = Array.from(traceRegistry.entries());
+          entries.sort((a, b) => a[1] - b[1]);
+          entries.forEach(([id, idx]) => {
+            const newIndex = idx > index ? idx - 1 : idx;
+            traceRegistry.set(id, newIndex);
+          });
+        });
+      }
+
+      function setUnitMode(mode) {
+        currentUnitMode = mode;
+        const firstPayload = spectraPayload[0];
+        if (firstPayload) {
+          Plotly.relayout(plotElement, {
+            'xaxis.title': firstPayload[mode].axis_title,
+            'yaxis.title': firstPayload[mode].flux_title,
+          });
+        }
+        traceRegistry.forEach((traceIndex, spectrumId) => {
+          const payload = spectraById.get(spectrumId);
+          if (!payload) {
+            return;
+          }
+          const data = payload[mode];
+          Plotly.restyle(plotElement, {
+            x: [data.x],
+            y: [data.y],
+            name: [data.trace_name],
+          }, [traceIndex]);
+        });
+      }
+    </script>
+  </body>
+</html>
+"""
+
+
+@APP.get("/", response_class=HTMLResponse)
+async def index() -> HTMLResponse:
+    """Serve the interactive viewer shell."""
+
+    return HTMLResponse(content=_render_shell())
+
+
+@APP.get("/api/spectra")
+async def fetch_spectra(
+    program_id: Optional[str] = Query(default=None),
+    target: Optional[str] = Query(default=None),
+    instrument: Optional[str] = Query(default=None),
+    flux_unit: str = Query(default="Jy"),
+    wave_unit: str = Query(default="micron"),
+    download_dir: str = Query(default="downloads"),
+) -> Dict[str, object]:
+    """Return serialized spectra for the requested criteria."""
+
+    if not program_id and not target:
+        raise HTTPException(status_code=400, detail="Provide a program_id or target name.")
+
+    try:
+        flux = u.Unit(flux_unit)
+        wave = u.Unit(wave_unit)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid unit specification: {exc}")
+
+    client = _build_client(Path(download_dir))
+    try:
+        observations, products, paths, metadata = client.discover_and_download(
+            program_id=program_id,
+            instrument_name=instrument,
+            target_name=target,
+        )
+    except JWSTDiscoveryError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    if not paths:
+        raise HTTPException(status_code=404, detail="No spectral products were found.")
+
+    loader = _build_loader(flux, wave)
+    spectra: Dict[str, Spectrum1D] = {}
+    header_metadata: Dict[str, Optional[str]] = {}
+    primary_spectrum_id: Optional[str] = None
+
+    for index, path in enumerate(paths):
+        try:
+            bundle = loader.load(path)
+        except Exception as exc:  # pragma: no cover - defensive against FITS parsing issues
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to load spectrum '{path.name}': {exc}",
+            ) from exc
+        spectra[path.name] = bundle.spectrum
+        if index == 0:
+            header_metadata = {
+                **{
+                    key: (str(value) if value is not None else None)
+                    for key, value in bundle.header_metadata.items()
+                },
+                "round_trip_verified": str(bundle.round_trip_verified),
+                "primary_product": path.name,
+            }
+            primary_spectrum_id = path.name
+
+    figure_spec, metadata_rows, spectra_payload, primary_id, provenance_rows = build_viewer_payload(
+        spectra,
+        metadata=metadata,
+        header_metadata=header_metadata,
+        primary_spectrum_id=primary_spectrum_id,
+    )
+
+    response: Dict[str, object] = {
+        "figure": figure_spec,
+        "metadata": metadata_rows,
+        "spectra": spectra_payload,
+        "primary_spectrum_id": primary_id,
+        "provenance_html": provenance_rows,
+    }
+    if client.last_query_relaxed_message:
+        response["warning"] = client.last_query_relaxed_message
+    return response
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Launch the JWST Spectral Explorer web UI")
+    parser.add_argument("--host", default="127.0.0.1", help="Host interface for the FastAPI server")
+    parser.add_argument("--port", type=int, default=8000, help="Port for the FastAPI server")
+    parser.add_argument(
+        "--reload", action="store_true", help="Enable auto-reload (development only)"
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    uvicorn.run("jwst_viewer.webapp:APP", host=args.host, port=args.port, reload=args.reload)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a FastAPI-powered JWST Spectral Explorer web UI with a persistent search form and Plotly viewer
- refactor the viewer serialization into a reusable payload builder for both the CLI HTML and the web API
- document the new launch command, dependencies, and implementation notes updates for the browser-based workflow
- harden MAST discovery by broadening target-only searches via cone lookup and surfacing service failures as clear API errors

## Testing
- PYTHONPATH=src python -m jwst_viewer.webapp --host 127.0.0.1 --port 8000 --help
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d724a082f4832988b9812579aa26f3