### PR TITLE
Update run.cmd to set up venv and launch UI

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -1,6 +1,14 @@
-cd C:/Code3/beta 
-python -m venv .venv 
-.venv/Scripts/Activate.ps1
-C:\Code3\beta\.venv\Scripts\python.exe -m pip install --upgrade pip
-pip install -e . 
-python -m http.server 8501
+@echo off
+setlocal enabledelayedexpansion
+
+cd /d "%~dp0"
+
+if not exist ".venv\Scripts\activate.bat" (
+    python -m venv .venv
+)
+
+call ".venv\Scripts\activate.bat"
+
+pip install -e .
+
+streamlit run -m spectral_app.interface.streamlit_app


### PR DESCRIPTION
## Summary
- switch run.cmd to use its own directory instead of a hard-coded path
- ensure a virtual environment exists, activate it, and install editable dependencies
- start the Streamlit UI entry point described in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d807aeaca08329aef58062f1cc344f