### PR TITLE
Improve Windows run script setup

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -1,14 +1,37 @@
 @echo off
 setlocal enabledelayedexpansion
 
-cd /d "%~dp0"
+set "REPO_DIR=%~dp0"
+pushd "%REPO_DIR%" >nul
 
 if not exist ".venv\Scripts\activate.bat" (
+    echo Creating virtual environment...
     python -m venv .venv
+    if errorlevel 1 (
+        echo Failed to create virtual environment.
+        popd >nul
+        exit /b 1
+    )
 )
 
 call ".venv\Scripts\activate.bat"
+if errorlevel 1 (
+    echo Failed to activate virtual environment.
+    popd >nul
+    exit /b 1
+)
 
-pip install -e .
+if not exist ".venv\Lib\site-packages\spectral_app.egg-link" (
+    echo Installing dependencies...
+    pip install -e .
+    if errorlevel 1 (
+        echo Failed to install dependencies.
+        popd >nul
+        exit /b 1
+    )
+)
 
 streamlit run -m spectral_app.interface.streamlit_app
+
+popd >nul
+endlocal


### PR DESCRIPTION
## Summary
- change the Windows run script to derive the repository path from the script location
- automatically create and activate the virtual environment before running the app
- install editable dependencies when missing and launch the Streamlit UI following the README instructions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8097372988329a4cbdd6a0994e0a2