### PR TITLE
Fix Streamlit command in run script

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -31,7 +31,7 @@ if not exist ".venv\Lib\site-packages\spectral_app.egg-link" (
     )
 )
 
-streamlit run -m spectral_app.interface.streamlit_app
+python -m streamlit run spectral_app/interface/streamlit_app.py
 
 popd >nul
 endlocal


### PR DESCRIPTION
## Summary
- update the Windows run script to launch Streamlit via `python -m streamlit`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80b545c548329aecab4f835e40af2