### PR TITLE
Improve run script dependency detection

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -21,7 +21,19 @@ if errorlevel 1 (
     exit /b 1
 )
 
-if not exist ".venv\Lib\site-packages\spectral_app.egg-link" (
+set "EGG_LINK=.venv\Lib\site-packages\spectral_analysis_app.egg-link"
+set "DIST_INFO_PATTERN=.venv\Lib\site-packages\spectral_analysis_app-*.dist-info"
+
+set "INSTALL_NEEDED=1"
+if exist "%EGG_LINK%" (
+    set "INSTALL_NEEDED=0"
+) else (
+    for /f "delims=" %%D in ('dir /b /ad "%DIST_INFO_PATTERN%" 2^>nul') do (
+        set "INSTALL_NEEDED=0"
+    )
+)
+
+if "!INSTALL_NEEDED!"=="1" (
     echo Installing dependencies...
     pip install -e .
     if errorlevel 1 (


### PR DESCRIPTION
## Summary
- update run.cmd to check for the spectral_analysis_app egg-link
- add support for detecting installed dist-info metadata before reinstalling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80ca460988329af1fe825d5454df7