### PR TITLE
Fix Streamlit invocation in run script

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -43,7 +43,8 @@ if "!INSTALL_NEEDED!"=="1" (
     )
 )
 
-python -m streamlit run spectral_app/interface/streamlit_app.py
+python -m streamlit run src/spectral_app/interface/streamlit_app.py
+set "STREAMLIT_EXIT_CODE=%ERRORLEVEL%"
 
 popd >nul
-endlocal
+endlocal & exit /b %STREAMLIT_EXIT_CODE%


### PR DESCRIPTION
## Summary
- update run.cmd to invoke Streamlit via a supported python -m call
- ensure the script returns Streamlit's exit code by capturing it before cleaning up

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d80f63ae3c8329b4272cd31b05b238