### PR TITLE
Use absolute imports in Streamlit interface

### DIFF
--- a/src/spectral_app/interface/streamlit_app.py
+++ b/src/spectral_app/interface/streamlit_app.py
@@ -8,13 +8,13 @@ from typing import List
 
 import streamlit as st
 
-from ..analysis.comparative import compute_difference, compute_ratio
-from ..datafetch.nist import fetch_reference_lines
-from ..ingestion.ascii_loader import load_ascii_spectrum
-from ..ingestion.fits_loader import load_fits_spectrum
-from ..models import Annotation, ReferenceLine, SessionExport, SpectrumRecord
-from ..plotting.plotly_view import add_annotations, add_reference_lines, add_spectrum_trace, create_base_figure
-from ..utils.export import export_session
+from spectral_app.analysis.comparative import compute_difference, compute_ratio
+from spectral_app.datafetch.nist import fetch_reference_lines
+from spectral_app.ingestion.ascii_loader import load_ascii_spectrum
+from spectral_app.ingestion.fits_loader import load_fits_spectrum
+from spectral_app.models import Annotation, ReferenceLine, SessionExport, SpectrumRecord
+from spectral_app.plotting.plotly_view import add_annotations, add_reference_lines, add_spectrum_trace, create_base_figure
+from spectral_app.utils.export import export_session
 
 
 def _init_state() -> None:


### PR DESCRIPTION
## Summary
- switch relative imports in the Streamlit interface to absolute spectral_app imports so it can be executed as a script

## Testing
- streamlit run src/spectral_app/interface/streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d8118f1adc8329801e79292ac607c9