### PR TITLE
Add main guard to Streamlit app entry point

### DIFF
--- a/src/spectral_app/interface/streamlit_app.py
+++ b/src/spectral_app/interface/streamlit_app.py
@@ -153,3 +153,7 @@ def run() -> None:
     _init_state()
     _render_sidebar()
     _render_main_panel()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add a __main__ guard so running the Streamlit module directly invokes run()

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d812d0beb883298cf443c4d1efe2c0