### PR TITLE
Prevent duplicate spectrum uploads in Streamlit sidebar

### DIFF
--- a/src/spectral_app/interface/streamlit_app.py
+++ b/src/spectral_app/interface/streamlit_app.py
@@ -48,10 +48,15 @@ def _render_sidebar() -> None:
             type=["csv", "txt", "tsv", "dat", "fits", "fit", "fts"],
             accept_multiple_files=True,
         )
+        existing_identifiers = {record.identifier for record in st.session_state.spectra}
         for file in uploaded or []:
+            if file.name in existing_identifiers:
+                st.info(f"Skipping already loaded spectrum {file.name}")
+                continue
             try:
                 record = _load_uploaded_file(file)
                 st.session_state.spectra.append(record)
+                existing_identifiers.add(record.identifier)
                 st.success(f"Loaded {file.name}")
             except Exception as exc:
                 st.error(f"Failed to load {file.name}: {exc}")


### PR DESCRIPTION
## Summary
- collect existing spectrum identifiers before processing uploads
- skip uploaded files whose identifiers are already present and update the identifier set after successful loads

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d8153b2ccc8329a755707f7f52be94