### PR TITLE
Reset reference lines when no selections available

### DIFF
--- a/src/spectral_app/interface/streamlit_app.py
+++ b/src/spectral_app/interface/streamlit_app.py
@@ -86,6 +86,8 @@ def _render_sidebar() -> None:
                 except Exception as exc:
                     st.warning(f"Failed to fetch {element}: {exc}")
             st.session_state.reference_lines = lines
+        else:
+            st.session_state.reference_lines = []
 
         st.header("Analysis")
         if len(st.session_state.spectra) >= 2:


### PR DESCRIPTION
## Summary
- clear stored reference lines when no elements are selected or no spectra are loaded

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d81c75b3ac8329b782d286b3f1ff9b