### PR TITLE
Migrate to specutils Spectrum API

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -40,6 +40,10 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
   - _Summary:_ Replaced the JWST-only tooling with a modular spectral analysis suite featuring CSV/FITS ingestion, Plotly visualisation, NIST line overlays, comparative analysis, session export, and a Streamlit UI scaffold.
   - _Related Issues / Tickets:_ N/A
 
+- _Iteration:_ Spectrum API modernization
+  - _Summary:_ Migrated ingestion, analysis, and model layers from the deprecated `Spectrum1D` class to the new `specutils.Spectrum` API, updating construction sites, metadata bundling, and tests to align with the refreshed interface.
+  - _Related Issues / Tickets:_ N/A
+
 ## Documentation URLs Consulted
 - _Iteration:_ Initial JWST viewer build
   - _Authoritative Source:_ `Training Documents/Reference Links for app v3.docx`
@@ -82,6 +86,11 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
     - https://specutils.readthedocs.io/en/stable/spectrum1d.html
     - https://docs.streamlit.io/library/api-reference
     - https://astroquery.readthedocs.io/en/latest/index.html
+
+- _Iteration:_ Spectrum API modernization
+  - _Authoritative Source:_ `Training Documents/Reference Links for app v3.docx`
+  - _Additional References:_
+    - https://specutils.readthedocs.io/en/stable/spectrum.html
 
 
 ## Parsed Data Fields with Provenance
@@ -159,4 +168,8 @@ Treat the parsed link list derived from [`Training Documents/Reference Links for
 - _Iteration:_ Spectral analysis app rebuild
   - _Checks Performed:_ `pytest`
   - _Command Output / Evidence:_ Test suite covering ingestion, analysis, plotting, NIST fallback, and export passes, validating the rebuilt architecture.
+
+- _Iteration:_ Spectrum API modernization
+  - _Checks Performed:_ `pytest`; `timeout 5 streamlit run src/spectral_app/interface/streamlit_app.py --server.headless true --server.port 8501`
+  - _Command Output / Evidence:_ Automated tests passed without spectrum deprecation warnings, and the Streamlit UI launched headlessly without emitting Spectrum migration warnings prior to the timed shutdown.
 

--- a/src/spectral_app/analysis/comparative.py
+++ b/src/spectral_app/analysis/comparative.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
-from specutils import Spectrum1D  # type: ignore
+from specutils import Spectrum  # type: ignore
 from specutils.manipulation import LinearInterpolatedResampler  # type: ignore
 
 from ..models import CANONICAL_FLUX_UNIT, CANONICAL_WAVELENGTH_UNIT, SpectrumMetadata, SpectrumRecord
 
 
-def _resample_to(spectrum: Spectrum1D, target_axis) -> Spectrum1D:
+def _resample_to(spectrum: Spectrum, target_axis) -> Spectrum:
     resampler = LinearInterpolatedResampler(extrapolation_treatment="nan_fill")
     return resampler(spectrum, target_axis)
 
@@ -27,7 +27,7 @@ def _combine_metadata(op: str, first: SpectrumMetadata, second: SpectrumMetadata
     return SpectrumMetadata(source=description, description=description, extra=extra)
 
 
-def _canonical(record: SpectrumRecord) -> Spectrum1D:
+def _canonical(record: SpectrumRecord) -> Spectrum:
     return record.spectrum
 
 
@@ -36,7 +36,7 @@ def compute_difference(first: SpectrumRecord, second: SpectrumRecord, identifier
     target_axis = first.spectrum.spectral_axis
     resampled_second = _resample_to(second.spectrum, target_axis)
     flux = first.spectrum.flux - resampled_second.flux
-    spectrum = Spectrum1D(flux=flux.to(CANONICAL_FLUX_UNIT), spectral_axis=target_axis.to(CANONICAL_WAVELENGTH_UNIT))
+    spectrum = Spectrum(flux=flux.to(CANONICAL_FLUX_UNIT), spectral_axis=target_axis.to(CANONICAL_WAVELENGTH_UNIT))
     metadata = _combine_metadata("difference", first.metadata, second.metadata)
     return SpectrumRecord(identifier or f"{first.identifier}-minus-{second.identifier}", spectrum, metadata)
 
@@ -48,6 +48,6 @@ def compute_ratio(first: SpectrumRecord, second: SpectrumRecord, identifier: Opt
     safe_flux = resampled_second.flux.copy()
     safe_flux.value[np.abs(safe_flux.value) < epsilon] = epsilon
     ratio_flux = (first.spectrum.flux / safe_flux).decompose()
-    spectrum = Spectrum1D(flux=ratio_flux, spectral_axis=target_axis.to(CANONICAL_WAVELENGTH_UNIT))
+    spectrum = Spectrum(flux=ratio_flux, spectral_axis=target_axis.to(CANONICAL_WAVELENGTH_UNIT))
     metadata = _combine_metadata("ratio", first.metadata, second.metadata)
     return SpectrumRecord(identifier or f"{first.identifier}-over-{second.identifier}", spectrum, metadata)

--- a/src/spectral_app/ingestion/ascii_loader.py
+++ b/src/spectral_app/ingestion/ascii_loader.py
@@ -6,7 +6,7 @@ from typing import IO, Dict, Iterable, Optional, Tuple
 
 import numpy as np
 from astropy import units as u
-from specutils import Spectrum1D  # type: ignore
+from specutils import Spectrum  # type: ignore
 
 try:  # Optional dependency for rich parsing
     import pandas as pd
@@ -138,7 +138,7 @@ def load_ascii_spectrum(path: Path | str | IO[str], identifier: Optional[str] = 
     wavelengths = np.asarray(columns[wave_col], dtype=float) * wave_unit
     flux = np.asarray(columns[flux_col], dtype=float) * flux_unit
 
-    spectrum = Spectrum1D(flux=flux.to(CANONICAL_FLUX_UNIT), spectral_axis=wavelengths.to(CANONICAL_WAVELENGTH_UNIT))
+    spectrum = Spectrum(flux=flux.to(CANONICAL_FLUX_UNIT), spectral_axis=wavelengths.to(CANONICAL_WAVELENGTH_UNIT))
 
     metadata = SpectrumMetadata(
         source=source,

--- a/src/spectral_app/ingestion/fits_loader.py
+++ b/src/spectral_app/ingestion/fits_loader.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional
 
 from astropy.io import fits
 from astropy import units as u
-from specutils import Spectrum1D  # type: ignore
+from specutils import Spectrum  # type: ignore
 
 from ..models import CANONICAL_FLUX_UNIT, CANONICAL_WAVELENGTH_UNIT, SpectrumMetadata, SpectrumRecord
 
@@ -26,11 +26,11 @@ def _extract_metadata(header: fits.Header) -> Dict[str, str]:
 
 def load_fits_spectrum(path: Path | str, identifier: Optional[str] = None) -> SpectrumRecord:
     """Load a 1D spectrum from a FITS file."""
-    spectrum = Spectrum1D.read(path)
+    spectrum = Spectrum.read(path)
 
     spectral_axis = spectrum.spectral_axis.to(CANONICAL_WAVELENGTH_UNIT)
     flux = spectrum.flux.to(CANONICAL_FLUX_UNIT)
-    canonical = Spectrum1D(flux=flux, spectral_axis=spectral_axis)
+    canonical = Spectrum(flux=flux, spectral_axis=spectral_axis)
 
     with fits.open(path) as hdul:
         header = hdul[0].header

--- a/src/spectral_app/models.py
+++ b/src/spectral_app/models.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from astropy import units as u
-from specutils import Spectrum1D  # type: ignore
+from specutils import Spectrum  # type: ignore
 
 
 CANONICAL_WAVELENGTH_UNIT = u.nm
@@ -27,17 +27,17 @@ class SpectrumMetadata:
 
 @dataclass
 class SpectrumRecord:
-    """Bundle tying a Spectrum1D instance to its metadata."""
+    """Bundle tying a Spectrum instance to its metadata."""
 
     identifier: str
-    spectrum: Spectrum1D
+    spectrum: Spectrum
     metadata: SpectrumMetadata
 
     def to_canonical_units(self) -> "SpectrumRecord":
         """Return a copy of the record in the canonical display units."""
         spectral_axis = self.spectrum.spectral_axis.to(CANONICAL_WAVELENGTH_UNIT)
         flux = self.spectrum.flux.to(CANONICAL_FLUX_UNIT)
-        canonical = Spectrum1D(flux=flux, spectral_axis=spectral_axis)
+        canonical = Spectrum(flux=flux, spectral_axis=spectral_axis)
         return SpectrumRecord(identifier=self.identifier, spectrum=canonical, metadata=self.metadata)
 
 

--- a/tests/test_comparative.py
+++ b/tests/test_comparative.py
@@ -1,6 +1,6 @@
 import pytest
 from astropy import units as u
-from specutils import Spectrum1D
+from specutils import Spectrum
 
 from spectral_app.analysis.comparative import compute_difference, compute_ratio
 from spectral_app.models import SpectrumMetadata, SpectrumRecord
@@ -9,7 +9,7 @@ from spectral_app.models import SpectrumMetadata, SpectrumRecord
 def _make_record(identifier: str, flux_values):
     spectral_axis = u.Quantity([500, 510, 520], u.nm)
     flux = u.Quantity(flux_values, u.Jy)
-    spectrum = Spectrum1D(flux=flux, spectral_axis=spectral_axis)
+    spectrum = Spectrum(flux=flux, spectral_axis=spectral_axis)
     metadata = SpectrumMetadata(source=identifier, description="test")
     return SpectrumRecord(identifier=identifier, spectrum=spectrum, metadata=metadata)
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,7 +1,7 @@
 import json
 
 from astropy import units as u
-from specutils import Spectrum1D
+from specutils import Spectrum
 
 from spectral_app.models import Annotation, ReferenceLine, SessionExport, SpectrumMetadata, SpectrumRecord
 from spectral_app.utils.export import export_session
@@ -12,7 +12,7 @@ def test_export_session(tmp_path):
     flux = u.Quantity([1, 2], u.Jy)
     record = SpectrumRecord(
         identifier="sample",
-        spectrum=Spectrum1D(flux=flux, spectral_axis=spectral_axis),
+        spectrum=Spectrum(flux=flux, spectral_axis=spectral_axis),
         metadata=SpectrumMetadata(source="test"),
     )
     export = SessionExport(

--- a/tests/test_fits_loader.py
+++ b/tests/test_fits_loader.py
@@ -1,5 +1,5 @@
 from astropy import units as u
-from specutils import Spectrum1D
+from specutils import Spectrum
 
 from spectral_app.ingestion.fits_loader import load_fits_spectrum
 
@@ -7,7 +7,7 @@ from spectral_app.ingestion.fits_loader import load_fits_spectrum
 def test_load_fits_spectrum(tmp_path):
     wave = [500, 510, 520] * u.nm
     flux = [1, 2, 3] * u.Jy
-    spectrum = Spectrum1D(flux=flux, spectral_axis=wave)
+    spectrum = Spectrum(flux=flux, spectral_axis=wave)
 
     path = tmp_path / "sample.fits"
     spectrum.write(path)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,6 +1,6 @@
 import pytest
 from astropy import units as u
-from specutils import Spectrum1D
+from specutils import Spectrum
 
 from spectral_app.models import SpectrumMetadata, SpectrumRecord
 from spectral_app.plotting.plotly_view import add_spectrum_trace, create_base_figure
@@ -11,7 +11,7 @@ def test_add_spectrum_trace():
     flux = u.Quantity([1, 2, 3], u.Jy)
     record = SpectrumRecord(
         identifier="sample",
-        spectrum=Spectrum1D(flux=flux, spectral_axis=spectral_axis),
+        spectrum=Spectrum(flux=flux, spectral_axis=spectral_axis),
         metadata=SpectrumMetadata(source="test"),
     )
 


### PR DESCRIPTION
## Summary
- replace Spectrum1D usage across models, ingestion, and comparative analysis with the new specutils.Spectrum interface
- update ASCII/FITS loaders, downstream tests, and documentation notes to align with the modernized API

## Testing
- pytest
- timeout 5 streamlit run src/spectral_app/interface/streamlit_app.py --server.headless true --server.port 8501

------
https://chatgpt.com/codex/tasks/task_e_68d81dac18048329b19b5e28aef932c8