### PR TITLE
Handle degenerate spectra and improve reference lines

### DIFF
--- a/src/spectral_app/datafetch/nist.py
+++ b/src/spectral_app/datafetch/nist.py
@@ -12,9 +12,17 @@ _SAMPLE_LINES = {
         ReferenceLine("H", 656.281 * u.nm, 1.0, "Hα"),
         ReferenceLine("H", 486.133 * u.nm, 0.7, "Hβ"),
     ],
+    "He": [
+        ReferenceLine("He", 587.562 * u.nm, 0.6, "He I"),
+        ReferenceLine("He", 447.148 * u.nm, 0.4, "He I"),
+    ],
     "Na": [
         ReferenceLine("Na", 589.592 * u.nm, 0.8, "Na D2"),
         ReferenceLine("Na", 588.995 * u.nm, 0.7, "Na D1"),
+    ],
+    "C": [
+        ReferenceLine("C", 658.288 * u.nm, 0.5, "C II"),
+        ReferenceLine("C", 711.318 * u.nm, 0.3, "C I"),
     ],
 }
 

--- a/src/spectral_app/ingestion/fits_loader.py
+++ b/src/spectral_app/ingestion/fits_loader.py
@@ -6,6 +6,7 @@ from typing import Dict, Optional
 
 from astropy.io import fits
 from astropy import units as u
+from astropy.units import UnitConversionError
 from specutils import Spectrum  # type: ignore
 
 from ..models import CANONICAL_FLUX_UNIT, CANONICAL_WAVELENGTH_UNIT, SpectrumMetadata, SpectrumRecord
@@ -29,7 +30,10 @@ def load_fits_spectrum(path: Path | str, identifier: Optional[str] = None) -> Sp
     spectrum = Spectrum.read(path)
 
     spectral_axis = spectrum.spectral_axis.to(CANONICAL_WAVELENGTH_UNIT)
-    flux = spectrum.flux.to(CANONICAL_FLUX_UNIT)
+    try:
+        flux = spectrum.flux.to(CANONICAL_FLUX_UNIT)
+    except UnitConversionError:
+        flux = spectrum.flux
     canonical = Spectrum(flux=flux, spectral_axis=spectral_axis)
 
     with fits.open(path) as hdul:

--- a/src/spectral_app/models.py
+++ b/src/spectral_app/models.py
@@ -1,11 +1,12 @@
 """Core data models for the spectral analysis application."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Dict, List, Optional
 
 from astropy import units as u
+from astropy.units import UnitConversionError
 from specutils import Spectrum  # type: ignore
 
 
@@ -36,9 +37,20 @@ class SpectrumRecord:
     def to_canonical_units(self) -> "SpectrumRecord":
         """Return a copy of the record in the canonical display units."""
         spectral_axis = self.spectrum.spectral_axis.to(CANONICAL_WAVELENGTH_UNIT)
-        flux = self.spectrum.flux.to(CANONICAL_FLUX_UNIT)
+        try:
+            flux = self.spectrum.flux.to(CANONICAL_FLUX_UNIT)
+            flux_unit = CANONICAL_FLUX_UNIT
+        except UnitConversionError:
+            flux = self.spectrum.flux
+            flux_unit = flux.unit
         canonical = Spectrum(flux=flux, spectral_axis=spectral_axis)
-        return SpectrumRecord(identifier=self.identifier, spectrum=canonical, metadata=self.metadata)
+        unit_label = flux_unit.to_string() if hasattr(flux_unit, "to_string") else str(flux_unit)
+        if unit_label in {"", "1"}:
+            unit_label = "dimensionless"
+        extra = dict(self.metadata.extra)
+        extra["flux_unit"] = unit_label
+        metadata = replace(self.metadata, extra=extra)
+        return SpectrumRecord(identifier=self.identifier, spectrum=canonical, metadata=metadata)
 
 
 @dataclass

--- a/src/spectral_app/plotting/plotly_view.py
+++ b/src/spectral_app/plotting/plotly_view.py
@@ -14,7 +14,7 @@ def create_base_figure(title: str = "Spectral Analysis") -> go.Figure:
     fig.update_layout(
         title=title,
         xaxis_title="Wavelength (nm)",
-        yaxis_title="Flux (Jy)",
+        yaxis_title="Flux",
         template="plotly_white",
         legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
     )
@@ -36,9 +36,15 @@ def add_spectrum_trace(
     max_points: Optional[int] = 5000,
     secondary_y: bool = False,
 ) -> None:
-    spectrum = record.to_canonical_units().spectrum
+    canonical_record = record.to_canonical_units()
+    spectrum = canonical_record.spectrum
     wavelengths = spectrum.spectral_axis.value
     flux = spectrum.flux.value
+    flux_unit = spectrum.flux.unit
+    flux_unit_label = flux_unit.to_string() if hasattr(flux_unit, "to_string") else str(flux_unit)
+    if flux_unit_label in {"", "1"}:
+        flux_unit_label = "dimensionless"
+    fig.update_yaxes(title=f"Flux ({flux_unit_label})")
     if max_points is not None:
         indices = _downsample(wavelengths, max_points)
         wavelengths = wavelengths[indices]
@@ -50,7 +56,7 @@ def add_spectrum_trace(
             name=record.identifier,
             mode="lines",
             line=dict(color=color),
-            hovertemplate="λ=%{x:.3f} nm<br>F=%{y:.3e} Jy",)
+            hovertemplate=f"λ=%{{x:.3f}} nm<br>F=%{{y:.3e}} {flux_unit_label}",)
     )
     if secondary_y:
         fig.update_layout(yaxis2=dict(title="Derived", overlaying="y", side="right"))

--- a/src/spectral_app/utils/export.py
+++ b/src/spectral_app/utils/export.py
@@ -12,10 +12,15 @@ from ..models import Annotation, ReferenceLine, SessionExport, SpectrumRecord
 
 def _serialize_spectrum(record: SpectrumRecord) -> Dict[str, object]:
     canonical = record.to_canonical_units().spectrum
+    flux_unit = canonical.flux.unit
+    flux_unit_label = flux_unit.to_string() if hasattr(flux_unit, "to_string") else str(flux_unit)
+    if flux_unit_label in {"", "1"}:
+        flux_unit_label = "dimensionless"
     return {
         "id": record.identifier,
         "wavelength_nm": canonical.spectral_axis.value.tolist(),
-        "flux_jy": canonical.flux.value.tolist(),
+        "flux": canonical.flux.value.tolist(),
+        "flux_unit": flux_unit_label,
         "metadata": {
             "source": record.metadata.source,
             "target": record.metadata.target,


### PR DESCRIPTION
## Summary
- deduplicate and sort ASCII spectra while tolerating unconvertible flux units
- fall back gracefully when FITS or runtime conversions cannot reach Jy
- enrich reference line defaults and propagate unit metadata through plotting and export

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8272bc8048329a743e7ae53bf4bf0